### PR TITLE
fix: add missing emailToAccount property when save state

### DIFF
--- a/api/script/storage/json-storage.ts
+++ b/api/script/storage/json-storage.ts
@@ -104,6 +104,7 @@ export class JsonStorage implements storage.Storage {
       accessKeyToAccountMap: this.accessKeyToAccountMap,
       accountToAccessKeysMap: this.accountToAccessKeysMap,
       accessKeyNameToAccountIdMap: this.accessKeyNameToAccountIdMap,
+      emailToAccountMap: this.emailToAccountMap,
     };
 
     const str = JSON.stringify(obj);

--- a/api/script/storage/redis-s3-storage.ts
+++ b/api/script/storage/redis-s3-storage.ts
@@ -109,6 +109,7 @@ export class RedisS3Storage implements storage.Storage {
       accessKeyToAccountMap: this.accessKeyToAccountMap,
       accountToAccessKeysMap: this.accountToAccessKeysMap,
       accessKeyNameToAccountIdMap: this.accessKeyNameToAccountIdMap,
+      emailToAccountMap: this.emailToAccountMap,
     };
     const str = JSON.stringify(obj);
 


### PR DESCRIPTION
I found a problem missing emailToAccount property in saveStateAsync function logic. Due to this issue, emailToAccount is not saved in redis.